### PR TITLE
improve Dulko's TreeTagger support

### DIFF
--- a/src/org/exmaralda/dulko/treetagger/TreeTagger.java
+++ b/src/org/exmaralda/dulko/treetagger/TreeTagger.java
@@ -1,6 +1,6 @@
 // TreeTagger.java -- A class for tagging tokens by TreeTagger
-// Version 2.2
-// Andreas Nolda, Thomas Schmidt 2020-12-07
+// Version 2.3
+// Andreas Nolda 2020-12-08
 
 // cf. TreeTaggerWrapper.java at https://github.com/reckart/tt4j
 // and TreeTagger.java at https://github.com/Camille31/Swip
@@ -10,49 +10,65 @@ package org.exmaralda.dulko.treetagger;
 import java.io.File;
 import java.io.IOException;
 import static java.io.File.separator;
-
 import java.util.List;
 import java.util.ArrayList;
 import java.util.prefs.Preferences;
-
 import org.annolab.tt4j.TokenHandler;
 import org.annolab.tt4j.TreeTaggerWrapper;
-
 import org.exmaralda.tagging.TaggingProfiles;
 
 public class TreeTagger {
   List<String> posList = null;
   List<String> lemmaList = null;
 
-  String ENVIRONMENT_TREETAGGER_HOME = System.getenv("TREETAGGER_HOME");
-  String TREETAGER_HOME_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("directory", ENVIRONMENT_TREETAGGER_HOME);
-
-  String MODEL_FALLBACK_PATH = ENVIRONMENT_TREETAGGER_HOME + separator + "lib" + separator + "german.par";
-  String MODEL_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file", MODEL_FALLBACK_PATH);
-  String MODEL_ENCODING = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file-encoding", "UTF-8");
+  String TT_HOME_FALLBACK_PATH;
+  String TT_HOME_PATH;
+  String TT_MODEL_FALLBACK_PATH;
+  String TT_MODEL_PATH;
+  String TT_MODEL_ENCODING;
 
   public TreeTagger() throws IOException {
     System.out.println("Initialising TreeTagger");
 
-    File f1 = new File(TREETAGER_HOME_PATH);
-    if (!f1.exists()){throw new IOException("TreeTagger home directory " + TREETAGER_HOME_PATH + " does not exist.");}
-    if (!f1.canRead()){throw new IOException("TreeTagger home directory " + TREETAGER_HOME_PATH + " cannot be read.");}
+    TT_HOME_FALLBACK_PATH = System.getenv("TREETAGGER_HOME");
+    TT_HOME_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("directory", TT_HOME_FALLBACK_PATH);
 
-    File f2 = new File(MODEL_PATH);
-    if (!f2.exists()){throw new IOException("TreeTagger parameter file " + MODEL_PATH + " does not exist.");}
-    if (!f2.canRead()){throw new IOException("TreeTagger parameter file " + MODEL_PATH + " cannot be read.");}
+    if (TT_HOME_PATH == null) {
+      throw new IOException("TreeTagger directory is unset.");
+    }
+    File f1 = new File(TT_HOME_PATH);
+    if (!f1.exists()) {
+      throw new IOException("TreeTagger directory " + TT_HOME_PATH + " does not exist.");
+    } else if (!f1.canRead()) {
+      throw new IOException("TreeTagger directory " + TT_HOME_PATH + " cannot be read.");
+    }
 
-    System.setProperty("treetagger.home", TREETAGER_HOME_PATH);
+    System.setProperty("treetagger.home", TT_HOME_PATH);
+
+    TT_MODEL_FALLBACK_PATH = TT_HOME_FALLBACK_PATH + separator + "lib" + separator + "german.par";
+    TT_MODEL_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file", TT_MODEL_FALLBACK_PATH);
+    TT_MODEL_ENCODING = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file-encoding", "UTF-8");
+
+    if (TT_MODEL_PATH == null) {
+      throw new IOException("TreeTagger parameter file is unset.");
+    }
+    File f2 = new File(TT_MODEL_PATH);
+    if (!f2.exists()) {
+      throw new IOException("TreeTagger parameter file " + TT_MODEL_PATH + " does not exist.");
+    } else if (!f2.canRead()) {
+      throw new IOException("TreeTagger parameter file " + TT_MODEL_PATH + " cannot be read.");
+    }
+
   }
 
   public String getHome() {
     System.out.println("Getting TreeTagger home directory");
-    return TREETAGER_HOME_PATH;
+    return TT_HOME_PATH;
   }
 
   public String getModel() {
     System.out.println("Getting TreeTagger parameter file");
-    return MODEL_PATH;
+    return TT_MODEL_PATH;
   }
 
   public void tag(String[] tokenArray) throws Exception {
@@ -60,7 +76,7 @@ public class TreeTagger {
     lemmaList = new ArrayList<String>();
 
     TreeTaggerWrapper tt = new TreeTaggerWrapper<String>();
-    tt.setModel(MODEL_PATH + ":" + MODEL_ENCODING);
+    tt.setModel(TT_MODEL_PATH + ":" + TT_MODEL_ENCODING);
     tt.setHandler(new TokenHandler<String>() {
       @Override
       public void token(String token, String pos, String lemma) {
@@ -68,7 +84,6 @@ public class TreeTagger {
         lemmaList.add(lemma);
       }
     });
-
     try {
       System.out.println("Running TreeTagger");
       tt.process(tokenArray);
@@ -81,7 +96,6 @@ public class TreeTagger {
 
   public String[] pos(String[] tokenArray) throws Exception {
     String[] posArray = null;
-
     try {
       System.out.println("Seeking POS tags");
       tag(tokenArray);
@@ -89,13 +103,11 @@ public class TreeTagger {
     } catch (Exception e) {
       e.printStackTrace();
     }
-
     return posArray;
   }
 
   public String[] lemma(String[] tokenArray) throws Exception {
     String[] lemmaArray = null;
-
     try {
       System.out.println("Seeking lemmas");
       tag(tokenArray);
@@ -103,7 +115,6 @@ public class TreeTagger {
     } catch (Exception e) {
       e.printStackTrace();
     }
-
     return lemmaArray;
   }
 }

--- a/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-tag.xsl
+++ b/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-tag.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- exb2exb-tag.xsl -->
-<!-- Version 12.0 -->
-<!-- Andreas Nolda 2020-12-07 -->
+<!-- Version 12.1 -->
+<!-- Andreas Nolda 2020-12-08 -->
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -16,11 +16,15 @@
 <xsl:variable name="tagger"
               select="tt:new()"/>
 
+<xsl:param name="tagger-home"
+           select="tt:getHome($tagger)"/>
+
 <xsl:param name="tagger-model"
            select="tt:getModel($tagger)"/>
 
 <xsl:param name="tagger-model-uri">
-  <xsl:if test="string-length($tagger-lang)&gt;0">
+  <xsl:if test="string-length($tagger-lang)&gt;0 and
+                string-length($tagger-model)&gt;0">
     <xsl:text>file://</xsl:text>
     <xsl:choose>
       <!-- Microsoft Windows: -->
@@ -38,7 +42,13 @@
 <xsl:template match="basic-body">
   <xsl:choose>
     <xsl:when test="string-length($tagger-lang)=0">
-      <xsl:message terminate="yes">Error: The first language used in the speakertable is unsupported by the tagger.</xsl:message>
+      <xsl:message terminate="yes">Error: The first language used in the speakertable is unsupported by TreeTagger.</xsl:message>
+    </xsl:when>
+    <xsl:when test="string-length($tagger-home)=0">
+      <xsl:message terminate="yes">Error: The TreeTagger directory is unset.</xsl:message>
+    </xsl:when>
+    <xsl:when test="string-length($tagger-model)=0">
+      <xsl:message terminate="yes">Error: The parameter file to be used by TreeTagger is unset.</xsl:message>
     </xsl:when>
     <xsl:when test="not(matches($tagger-model-uri,concat('/[^/.]*',$tagger-lang)))">
       <xsl:message terminate="yes">Error: The first language used in the speakertable does not match the parameter file used by TreeTagger.</xsl:message>

--- a/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-word.xsl
+++ b/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-word.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- exb2exb-word.xsl -->
-<!-- Version 12.1 -->
+<!-- Version 12.2 -->
 <!-- Andreas Nolda 2020-12-08 -->
 
 <xsl:stylesheet version="2.0"
@@ -197,7 +197,19 @@
                       regex="{'\s+'}">
     <xsl:non-matching-substring>
       <xsl:choose>
-        <!-- abbreviations -->
+        <!-- one-letter abbreviations: -->
+        <xsl:when test="matches(.,'^\p{P}*\p{L}\.\p{P}*$')">
+          <xsl:analyze-string select="."
+                              regex="{'\p{L}\.'}">
+            <xsl:matching-substring>
+              <xsl:call-template name="tokenize-word"/>
+            </xsl:matching-substring>
+            <xsl:non-matching-substring>
+              <xsl:call-template name="tokenize-punctuation"/>
+            </xsl:non-matching-substring>
+          </xsl:analyze-string>
+        </xsl:when>
+        <!-- other abbreviations: -->
         <xsl:when test="$abbreviations/abbr[contains(current(),.) and
                                             matches(substring-before(current(),.),'^\p{P}*$') and
                                             matches(substring-after(current(),.),'^\p{P}*$')]">

--- a/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-word.xsl
+++ b/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-word.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- exb2exb-word.xsl -->
-<!-- Version 12.0 -->
-<!-- Andreas Nolda 2020-12-07 -->
+<!-- Version 12.1 -->
+<!-- Andreas Nolda 2020-12-08 -->
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -23,7 +23,8 @@
            select="tt:getHome($tagger)"/>
 
 <xsl:param name="tagger-abbreviations-uri">
-  <xsl:if test="string-length($tagger-lang)&gt;0">
+  <xsl:if test="string-length($tagger-lang)&gt;0 and
+                string-length($tagger-home)&gt;0">
     <xsl:text>file://</xsl:text>
     <xsl:choose>
       <!-- Microsoft Windows: -->


### PR DESCRIPTION
* fix a NPE when `TT_HOME_PATH == null`
* add more TreeTagger-related checks and error messages in the Dulko stylesheets
* tokenize at least one-letter abbreviations in case no TreeTagger abbreviations are found