### PR TITLE
properly use TreeTagger settings in Dulko stylesheets

### DIFF
--- a/src/org/exmaralda/dulko/treetagger/TreeTagger.java
+++ b/src/org/exmaralda/dulko/treetagger/TreeTagger.java
@@ -1,6 +1,6 @@
 // TreeTagger.java -- A class for tagging tokens by TreeTagger
-// Version 2.3
-// Andreas Nolda 2020-12-08
+// Version 2.4
+// Andreas Nolda 2023-07-17
 
 // cf. TreeTaggerWrapper.java at https://github.com/reckart/tt4j
 // and TreeTagger.java at https://github.com/Camille31/Swip
@@ -18,103 +18,141 @@ import org.annolab.tt4j.TreeTaggerWrapper;
 import org.exmaralda.tagging.TaggingProfiles;
 
 public class TreeTagger {
-  List<String> posList = null;
-  List<String> lemmaList = null;
+    List<String> posList = null;
+    List<String> lemmaList = null;
 
-  String TT_HOME_FALLBACK_PATH;
-  String TT_HOME_PATH;
-  String TT_MODEL_FALLBACK_PATH;
-  String TT_MODEL_PATH;
-  String TT_MODEL_ENCODING;
+    String TT_HOME_FALLBACK_PATH;
+    String TT_HOME_PATH;
+    String TT_MODEL_FALLBACK_PATH;
+    String TT_MODEL_PATH;
+    String TT_MODEL_ENCODING;
+    String TT_ABBR_FALLBACK_PATH;
+    String TT_ABBR_PATH;
+    String TT_ABBR_ENCODING;
 
-  public TreeTagger() throws IOException {
-    System.out.println("Initialising TreeTagger");
+    public TreeTagger() throws IOException {
+        System.err.println("Initialising TreeTagger");
 
-    TT_HOME_FALLBACK_PATH = System.getenv("TREETAGGER_HOME");
-    TT_HOME_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("directory", TT_HOME_FALLBACK_PATH);
+        TT_HOME_FALLBACK_PATH = System.getenv("TREETAGGER_HOME");
+        TT_HOME_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("directory", TT_HOME_FALLBACK_PATH);
+        if (TT_HOME_PATH == null) {
+            throw new IOException("TreeTagger directory is unset.");
+        } else if (TT_HOME_PATH.isEmpty()) {
+            if (TT_HOME_FALLBACK_PATH != null) {
+                TT_HOME_PATH = TT_HOME_FALLBACK_PATH;
+            } else {
+                throw new IOException("TreeTagger directory is unset.");
+            }
+        }
+        File f1 = new File(TT_HOME_PATH);
+        if (! f1.exists()) {
+            throw new IOException("TreeTagger directory does not exist.");
+        } else if (! f1.canRead()) {
+            throw new IOException("TreeTagger directory cannot be read.");
+        } else {
+            System.setProperty("treetagger.home", TT_HOME_PATH);
+        }
 
-    if (TT_HOME_PATH == null) {
-      throw new IOException("TreeTagger directory is unset.");
+        TT_MODEL_FALLBACK_PATH = TT_HOME_PATH + separator + "lib" + separator + "german.par";
+        TT_MODEL_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file", TT_MODEL_FALLBACK_PATH);
+        TT_MODEL_ENCODING = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file-encoding", "UTF-8");
+        if (TT_MODEL_PATH == null) {
+            throw new IOException("TreeTagger parameter file is unset.");
+        } else if (TT_MODEL_PATH.isEmpty()) {
+            TT_MODEL_PATH = TT_MODEL_FALLBACK_PATH;
+        }
+        File f2 = new File(TT_MODEL_PATH);
+        if (! f2.exists()) {
+            throw new IOException("TreeTagger parameter file does not exist.");
+        } else if (! f2.canRead()) {
+            throw new IOException("TreeTagger parameter file cannot be read.");
+        }
+
+        TT_ABBR_FALLBACK_PATH = TT_HOME_PATH + separator + "lib" + separator + "german-abbreviations";
+        TT_ABBR_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("abbreviations-file", TT_ABBR_FALLBACK_PATH);
+        TT_ABBR_ENCODING = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("abbreviations-file-encoding", "UTF-8");
+        if (TT_ABBR_PATH == null) {
+            System.err.println("TreeTagger abbreviations file is unset.");
+        } else if (TT_ABBR_PATH.isEmpty()) {
+            TT_ABBR_PATH = TT_ABBR_FALLBACK_PATH;
+        }
+        File f3 = new File(TT_ABBR_PATH);
+        if (! f3.exists()) {
+            throw new IOException("TreeTagger abbreviations file does not exist.");
+        } else if (! f3.canRead()) {
+            throw new IOException("TreeTagger abbreviations file cannot be read.");
+        }
     }
-    File f1 = new File(TT_HOME_PATH);
-    if (!f1.exists()) {
-      throw new IOException("TreeTagger directory " + TT_HOME_PATH + " does not exist.");
-    } else if (!f1.canRead()) {
-      throw new IOException("TreeTagger directory " + TT_HOME_PATH + " cannot be read.");
+
+    public String getHomePath() {
+        System.err.println("Using TreeTagger in " + TT_HOME_PATH);
+        return TT_HOME_PATH;
     }
 
-    System.setProperty("treetagger.home", TT_HOME_PATH);
-
-    TT_MODEL_FALLBACK_PATH = TT_HOME_FALLBACK_PATH + separator + "lib" + separator + "german.par";
-    TT_MODEL_PATH = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file", TT_MODEL_FALLBACK_PATH);
-    TT_MODEL_ENCODING = Preferences.userRoot().node(TaggingProfiles.PREFERENCES_NODE).get("parameter-file-encoding", "UTF-8");
-
-    if (TT_MODEL_PATH == null) {
-      throw new IOException("TreeTagger parameter file is unset.");
-    }
-    File f2 = new File(TT_MODEL_PATH);
-    if (!f2.exists()) {
-      throw new IOException("TreeTagger parameter file " + TT_MODEL_PATH + " does not exist.");
-    } else if (!f2.canRead()) {
-      throw new IOException("TreeTagger parameter file " + TT_MODEL_PATH + " cannot be read.");
+    public String getModelPath() {
+        System.err.println("Using TreeTagger parameter file " + TT_MODEL_PATH);
+        return TT_MODEL_PATH;
     }
 
-  }
-
-  public String getHome() {
-    System.out.println("Getting TreeTagger home directory");
-    return TT_HOME_PATH;
-  }
-
-  public String getModel() {
-    System.out.println("Getting TreeTagger parameter file");
-    return TT_MODEL_PATH;
-  }
-
-  public void tag(String[] tokenArray) throws Exception {
-    posList = new ArrayList<String>();
-    lemmaList = new ArrayList<String>();
-
-    TreeTaggerWrapper tt = new TreeTaggerWrapper<String>();
-    tt.setModel(TT_MODEL_PATH + ":" + TT_MODEL_ENCODING);
-    tt.setHandler(new TokenHandler<String>() {
-      @Override
-      public void token(String token, String pos, String lemma) {
-        posList.add(pos);
-        lemmaList.add(lemma);
-      }
-    });
-    try {
-      System.out.println("Running TreeTagger");
-      tt.process(tokenArray);
-    } catch (Exception e) {
-      e.printStackTrace();
-    } finally {
-      tt.destroy();
+    public String getModelEncoding() {
+        System.err.println("Using TreeTagger parameter file in " + TT_MODEL_ENCODING + " encoding");
+        return TT_MODEL_ENCODING;
     }
-  }
 
-  public String[] pos(String[] tokenArray) throws Exception {
-    String[] posArray = null;
-    try {
-      System.out.println("Seeking POS tags");
-      tag(tokenArray);
-      posArray = posList.toArray(new String[0]);
-    } catch (Exception e) {
-      e.printStackTrace();
+    public String getAbbrPath() {
+        System.err.println("Using TreeTagger abbreviations file " + TT_ABBR_PATH);
+        return TT_ABBR_PATH;
     }
-    return posArray;
-  }
 
-  public String[] lemma(String[] tokenArray) throws Exception {
-    String[] lemmaArray = null;
-    try {
-      System.out.println("Seeking lemmas");
-      tag(tokenArray);
-      lemmaArray = lemmaList.toArray(new String[0]);
-    } catch (Exception e) {
-      e.printStackTrace();
+    public String getAbbrEncoding() {
+        System.err.println("Using TreeTagger abbreviations file in " + TT_ABBR_ENCODING + " encoding");
+        return TT_ABBR_ENCODING;
     }
-    return lemmaArray;
-  }
+
+    public void tag(String[] tokenArray) throws Exception {
+        posList = new ArrayList<String>();
+        lemmaList = new ArrayList<String>();
+
+        TreeTaggerWrapper tt = new TreeTaggerWrapper<String>();
+        tt.setModel(TT_MODEL_PATH + ":" + TT_MODEL_ENCODING);
+        tt.setHandler(new TokenHandler<String>() {
+                @Override
+                public void token(String token, String pos, String lemma) {
+                    posList.add(pos);
+                    lemmaList.add(lemma);
+                }
+            });
+        try {
+            System.err.println("Running TreeTagger");
+            tt.process(tokenArray);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            tt.destroy();
+        }
+    }
+
+    public String[] pos(String[] tokenArray) throws Exception {
+        String[] posArray = null;
+        try {
+            System.err.println("Seeking POS tags");
+            tag(tokenArray);
+            posArray = posList.toArray(new String[0]);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return posArray;
+    }
+
+    public String[] lemma(String[] tokenArray) throws Exception {
+        String[] lemmaArray = null;
+        try {
+            System.err.println("Seeking lemmas");
+            tag(tokenArray);
+            lemmaArray = lemmaList.toArray(new String[0]);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return lemmaArray;
+    }
 }

--- a/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-tag.xsl
+++ b/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-tag.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- exb2exb-tag.xsl -->
-<!-- Version 12.1 -->
-<!-- Andreas Nolda 2020-12-08 -->
+<!-- Version 12.2 -->
+<!-- Andreas Nolda 2023-07-17 -->
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -17,14 +17,13 @@
               select="tt:new()"/>
 
 <xsl:param name="tagger-home"
-           select="tt:getHome($tagger)"/>
+           select="tt:getHomePath($tagger)"/>
 
 <xsl:param name="tagger-model"
-           select="tt:getModel($tagger)"/>
+           select="tt:getModelPath($tagger)"/>
 
-<xsl:param name="tagger-model-uri">
-  <xsl:if test="string-length($tagger-lang)&gt;0 and
-                string-length($tagger-model)&gt;0">
+<xsl:variable name="tagger-model-uri">
+  <xsl:if test="string-length($tagger-model)&gt;0">
     <xsl:text>file://</xsl:text>
     <xsl:choose>
       <!-- Microsoft Windows: -->
@@ -37,26 +36,28 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:if>
-</xsl:param>
+</xsl:variable>
 
 <xsl:template match="basic-body">
   <xsl:choose>
-    <xsl:when test="string-length($tagger-lang)=0">
-      <xsl:message terminate="yes">Error: The first language used in the speakertable is unsupported by TreeTagger.</xsl:message>
-    </xsl:when>
     <xsl:when test="string-length($tagger-home)=0">
       <xsl:message terminate="yes">Error: The TreeTagger directory is unset.</xsl:message>
     </xsl:when>
     <xsl:when test="string-length($tagger-model)=0">
-      <xsl:message terminate="yes">Error: The parameter file to be used by TreeTagger is unset.</xsl:message>
+      <xsl:message terminate="yes">Error: The TreeTagger parameter file is unset.</xsl:message>
     </xsl:when>
-    <xsl:when test="not(matches($tagger-model-uri,concat('/[^/.]*',$tagger-lang)))">
-      <xsl:message terminate="yes">Error: The first language used in the speakertable does not match the parameter file used by TreeTagger.</xsl:message>
+    <xsl:when test="string-length($lang)&gt;0 and
+                    string-length($tagger-lang)=0">
+      <xsl:message terminate="yes">Error: The first language used in the speakertable is unsupported by TreeTagger.</xsl:message>
+    </xsl:when>
+    <xsl:when test="string-length($lang)&gt;0 and
+                    not(matches($tagger-model-uri,concat('/[^/.]*',$tagger-lang)))">
+      <xsl:message terminate="yes">Error: The first language used in the speakertable does not match the TreeTagger parameter file.</xsl:message>
     </xsl:when>
     <xsl:otherwise>
       <xsl:message>
         <xsl:text>Using TreeTagger parameter file </xsl:text>
-        <xsl:value-of select="$tagger-model-uri"/>
+        <xsl:value-of select="$tagger-model"/>
       </xsl:message>
       <xsl:variable name="preceding-tiers">
         <!-- tiers preceding the reference tier -->

--- a/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-word.xsl
+++ b/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/exb2exb-word.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- exb2exb-word.xsl -->
-<!-- Version 12.2 -->
-<!-- Andreas Nolda 2020-12-08 -->
+<!-- Version 12.3 -->
+<!-- Andreas Nolda 2023-07-17 -->
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -19,33 +19,42 @@
 <xsl:variable name="tagger"
               select="tt:new()"/>
 
-<xsl:param name="tagger-home"
-           select="tt:getHome($tagger)"/>
+<xsl:param name="tagger-abbreviations"
+           select="tt:getAbbrPath($tagger)"/>
 
-<xsl:param name="tagger-abbreviations-uri">
-  <xsl:if test="string-length($tagger-lang)&gt;0 and
-                string-length($tagger-home)&gt;0">
+<xsl:param name="tagger-abbreviations-encoding"
+           select="tt:getAbbrEncoding($tagger)"/>
+
+<xsl:variable name="tagger-abbreviations-uri">
+  <xsl:if test="string-length($tagger-abbreviations)&gt;0">
     <xsl:text>file://</xsl:text>
     <xsl:choose>
       <!-- Microsoft Windows: -->
-      <xsl:when test="matches($tagger-home,'^[A-Z]:\\')">
+      <xsl:when test="matches($tagger-abbreviations,'^[A-Z]:\\')">
         <xsl:text>/</xsl:text>
-        <xsl:value-of select="translate($tagger-home,'\','/')"/>
+        <xsl:value-of select="translate($tagger-abbreviations,'\','/')"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="$tagger-home"/>
+        <xsl:value-of select="$tagger-abbreviations"/>
       </xsl:otherwise>
     </xsl:choose>
-    <xsl:text>/lib/</xsl:text>
-    <xsl:value-of select="$tagger-lang"/>
-    <xsl:text>-abbreviations</xsl:text>
   </xsl:if>
-</xsl:param>
+</xsl:variable>
 
 <xsl:variable name="abbreviations">
   <xsl:if test="string-length($tagger-abbreviations-uri)&gt;0">
-    <xsl:if test="unparsed-text-available($tagger-abbreviations-uri)">
-      <xsl:analyze-string select="unparsed-text($tagger-abbreviations-uri)"
+    <xsl:variable name="uri"
+                  select="$tagger-abbreviations-uri"/>
+    <xsl:variable name="encoding">
+      <xsl:choose>
+        <xsl:when test="string-length($tagger-abbreviations-encoding)&gt;0">
+          <xsl:value-of select="$tagger-abbreviations-encoding"/>
+        </xsl:when>
+        <xsl:otherwise>UTF-8</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="unparsed-text-available($uri,$encoding)">
+      <xsl:analyze-string select="unparsed-text($uri,$encoding)"
                           regex="\n">
         <xsl:non-matching-substring>
           <abbr>
@@ -58,73 +67,86 @@
 </xsl:variable>
 
 <xsl:template match="basic-body">
-  <xsl:if test="$abbreviations/abbr">
-    <xsl:message>
-      <xsl:text>Using abbreviations in </xsl:text>
-      <xsl:value-of select="$tagger-abbreviations-uri"/>
-    </xsl:message>
-  </xsl:if>
-  <xsl:variable name="potential-events">
-    <xsl:for-each select="common-timeline/tli">
-      <xsl:choose>
-        <!-- There is a corresponding non-annotated event on the reference tier. -->
-        <xsl:when test="../following-sibling::tier[@id=$reference-id]/event[@start=current()/@id]
-                                                                           [not(@start=../following-sibling::tier/event/@start)]/@start">
-          <event>
-            <xsl:attribute name="start"
-                           select="@id"/>
-            <xsl:for-each select="../following-sibling::tier[@id=$reference-id]/event[@start=current()/@id]">
-              <xsl:copy-of select="@end"/>
-              <!-- Tokenize it. -->
-              <xsl:call-template name="tokenize"/>
-            </xsl:for-each>
-          </event>
-        </xsl:when>
-        <!-- There is a no such event on the reference tier. -->
-        <xsl:otherwise>
-          <!-- Don't tokenize it. -->
-          <event>
-            <xsl:attribute name="start"
-                           select="@id"/>
-            <xsl:for-each select="../following-sibling::tier[@id=$reference-id]/event[@start=current()/@id]">
-              <xsl:copy-of select="@end"/>
+  <xsl:choose>
+    <xsl:when test="string-length($tagger-abbreviations)=0">
+      <xsl:message>Warning: The TreeTagger abbreviations file is unset.</xsl:message>
+    </xsl:when>
+    <xsl:when test="string-length($lang)&gt;0 and
+                    string-length($tagger-lang)=0">
+      <xsl:message>Warning: The first language used in the speakertable is unsupported by TreeTagger.</xsl:message>
+    </xsl:when>
+    <xsl:when test="string-length($lang)&gt;0 and
+                    not(matches($tagger-abbreviations-uri,concat('/[^/.]*',$tagger-lang)))">
+      <xsl:message terminate="yes">Error: The first language used in the speakertable does not match the TreeTagger abbreviations file.</xsl:message>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:message>
+        <xsl:text>Using TreeTagger abbreviations </xsl:text>
+        <xsl:value-of select="$tagger-abbreviations"/>
+      </xsl:message>
+      <xsl:variable name="potential-events">
+        <xsl:for-each select="common-timeline/tli">
+          <xsl:choose>
+            <!-- There is a corresponding non-annotated event on the reference tier. -->
+            <xsl:when test="../following-sibling::tier[@id=$reference-id]/event[@start=current()/@id]
+                                                                               [not(@start=../following-sibling::tier/event/@start)]/@start">
+              <event>
+                <xsl:attribute name="start"
+                               select="@id"/>
+                <xsl:for-each select="../following-sibling::tier[@id=$reference-id]/event[@start=current()/@id]">
+                  <xsl:copy-of select="@end"/>
+                  <!-- Tokenize it. -->
+                  <xsl:call-template name="tokenize"/>
+                </xsl:for-each>
+              </event>
+            </xsl:when>
+            <!-- There is a no such event on the reference tier. -->
+            <xsl:otherwise>
               <!-- Don't tokenize it. -->
-              <xsl:value-of select="."/>
-          </xsl:for-each>
-          </event>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:for-each>
-  </xsl:variable>
-  <xsl:variable name="preceding-tiers">
-    <!-- tiers preceding the reference tier -->
-    <xsl:apply-templates select="tier[following-sibling::tier[@id=$reference-id]]"/>
-  </xsl:variable>
-  <xsl:variable name="preceding-tier-number"
-                select="count($preceding-tiers/tier)"/>
-  <basic-body>
-    <xsl:call-template name="timeline">
-      <xsl:with-param name="potential-events"
-                      select="$potential-events"/>
-    </xsl:call-template>
-    <xsl:copy-of select="$preceding-tiers"/>
-    <!-- reference tier -->
-    <xsl:call-template name="tier">
-      <xsl:with-param name="preceding-tier-number"
-                      select="$preceding-tier-number"/>
-      <xsl:with-param name="category"
-                      select="$word"/>
-      <xsl:with-param name="type">t</xsl:with-param>
-      <xsl:with-param name="events">
-        <xsl:call-template name="word-events">
+              <event>
+                <xsl:attribute name="start"
+                               select="@id"/>
+                <xsl:for-each select="../following-sibling::tier[@id=$reference-id]/event[@start=current()/@id]">
+                  <xsl:copy-of select="@end"/>
+                  <!-- Don't tokenize it. -->
+                  <xsl:value-of select="."/>
+              </xsl:for-each>
+              </event>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:variable name="preceding-tiers">
+        <!-- tiers preceding the reference tier -->
+        <xsl:apply-templates select="tier[following-sibling::tier[@id=$reference-id]]"/>
+      </xsl:variable>
+      <xsl:variable name="preceding-tier-number"
+                    select="count($preceding-tiers/tier)"/>
+      <basic-body>
+        <xsl:call-template name="timeline">
           <xsl:with-param name="potential-events"
                           select="$potential-events"/>
         </xsl:call-template>
-      </xsl:with-param>
-    </xsl:call-template>
-    <!-- tiers following the reference tier -->
-    <xsl:apply-templates select="tier[preceding-sibling::tier[@id=$reference-id]]"/>
-  </basic-body>
+        <xsl:copy-of select="$preceding-tiers"/>
+        <!-- reference tier -->
+        <xsl:call-template name="tier">
+          <xsl:with-param name="preceding-tier-number"
+                          select="$preceding-tier-number"/>
+          <xsl:with-param name="category"
+                          select="$word"/>
+          <xsl:with-param name="type">t</xsl:with-param>
+          <xsl:with-param name="events">
+            <xsl:call-template name="word-events">
+              <xsl:with-param name="potential-events"
+                              select="$potential-events"/>
+            </xsl:call-template>
+          </xsl:with-param>
+        </xsl:call-template>
+        <!-- tiers following the reference tier -->
+        <xsl:apply-templates select="tier[preceding-sibling::tier[@id=$reference-id]]"/>
+      </basic-body>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <xsl:template name="tokenize-word">

--- a/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/lang.xsl
+++ b/src/org/exmaralda/partitureditor/jexmaralda/xsl/dulko/lang.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- lang.xsl -->
-<!-- Version 1.0 -->
-<!-- Andreas Nolda 2020-12-05 -->
+<!-- Version 1.1 -->
+<!-- Andreas Nolda 2023-07-17 -->
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -11,19 +11,17 @@
 
 <!-- code of language used in the speaker table -->
 <xsl:param name="lang">
-  <xsl:choose>
-    <xsl:when test="/basic-transcription/head/speakertable/speaker/languages-used/language[@lang]">
-      <!-- Select the first language used in the speaker table. -->
-      <xsl:value-of select="/basic-transcription/head/speakertable/speaker/languages-used/language[1]/@lang"/>
-    </xsl:when>
-    <xsl:otherwise>deu</xsl:otherwise><!-- default -->
-  </xsl:choose>
+  <xsl:if test="/basic-transcription/head/speakertable/speaker/languages-used/language[@lang]">
+    <!-- Select the first language used in the speaker table. -->
+    <xsl:value-of select="/basic-transcription/head/speakertable/speaker/languages-used/language[1]/@lang"/>
+  </xsl:if>
 </xsl:param>
 
 <!-- TreeTagger language name -->
 <!-- matches basenames of TreeTagger parameter files and abbreviation files (if any) -->
 <xsl:param name="tagger-lang">
   <xsl:choose>
+    <xsl:when test="$lang='bel'">belarusian</xsl:when>
     <xsl:when test="$lang='bul'">bulgarian</xsl:when>
     <xsl:when test="$lang='cop'">coptic</xsl:when>
     <xsl:when test="$lang='csc'">catalan</xsl:when>
@@ -38,12 +36,15 @@
     <xsl:when test="$lang='fra'">french</xsl:when>
     <xsl:when test="$lang='glg'">galician</xsl:when>
     <xsl:when test="$lang='hau'">hausa</xsl:when>
+    <xsl:when test="$lang='hun'">hungarian</xsl:when>
+    <xsl:when test="$lang='ind'">indonesian</xsl:when>
     <xsl:when test="$lang='ita'">italian</xsl:when>
     <xsl:when test="$lang='kor'">korean</xsl:when>
     <xsl:when test="$lang='lat'">latin</xsl:when>
     <xsl:when test="$lang='mgt'">mongolian</xsl:when>
     <xsl:when test="$lang='nld'">dutch</xsl:when>
     <xsl:when test="$lang='nor'">norwegian</xsl:when>
+    <xsl:when test="$lang='pes'">persian</xsl:when>
     <xsl:when test="$lang='pol'">polish</xsl:when>
     <xsl:when test="$lang='por'">portuguese</xsl:when>
     <xsl:when test="$lang='rms'">romanian</xsl:when>
@@ -53,6 +54,7 @@
     <xsl:when test="$lang='spa'">spanish</xsl:when>
     <xsl:when test="$lang='swe'">swedish</xsl:when>
     <xsl:when test="$lang='swh'">swahili</xsl:when>
+    <xsl:when test="$lang='ukr'">ukranian</xsl:when>
   </xsl:choose>
 </xsl:param>
 </xsl:stylesheet>


### PR DESCRIPTION
Fixes #407.
* add functions for TreeTagger abbrevations file to TreeTagger.java
* use TreeTagger settings for parameter and abbrevations files in exb2exb-word.xsl and exb2exb-tag.xsl
* throw an error if the language of the TreeTagger parameter and abbrevation files differ from the first language used in the speaker table